### PR TITLE
Retried preparing for out_norikra

### DIFF
--- a/lib/fluent/plugin/norikra/output.rb
+++ b/lib/fluent/plugin/norikra/output.rb
@@ -97,7 +97,6 @@ module Fluent::NorikraPlugin
             @registered_targets.delete(t.name)
           else
             log.error "Failed to prepare norikra data for target:#{t.name}"
-            @norikra_started.push(t)
           end
         end
       end


### PR DESCRIPTION
We run patched fluent-plugin-norikra gem in our production for a week without any problem.

We confirmed that the out-norikra resume after any failure by checking td-agent.log.

Thank you for reply.