### PR TITLE
Fix "BUG: output plugins MUST implement this method" when used with Fluentd 0.14.x

### DIFF
--- a/lib/fluent/plugin/out_norikra.rb
+++ b/lib/fluent/plugin/out_norikra.rb
@@ -68,5 +68,12 @@ module Fluent
     def fetchable?
       true
     end
+
+    # For Fluentd 0.14 compatibility.
+    # Fluent::Compat::BufferedOutput expects the plugin class itself
+    # (but not its included module) to define `format_stream` when overriding.
+    def format_stream(*)
+      super
+    end
   end
 end


### PR DESCRIPTION
When overriding `Fluent::Compat::BufferedOutput#format_stream`, Fluentd 0.14 expects the plugin class itself, but no its included module, to define `format_stream` method.
`format` method, which is not implemented by out_norikra, is otherwise invoked and a `NotImplementedError` is raised.

In order to fix this issue, this patch defines `NorikraOutput#format_stream`, which just delegates to the `OutputMixin` module.

I don't know this is the best solution or the problem can be addressed on the Fluentd side...